### PR TITLE
Feature/io 54/mobile chart

### DIFF
--- a/frontend/src/app/content/chart/chart.component.css
+++ b/frontend/src/app/content/chart/chart.component.css
@@ -1,0 +1,3 @@
+.chart-wrapper {
+  height: 100%;
+}

--- a/frontend/src/app/content/chart/chart.component.ts
+++ b/frontend/src/app/content/chart/chart.component.ts
@@ -12,7 +12,7 @@ export class ChartComponent implements OnChanges {
   @Input() labels: string[] = [];
   chartDatasets: { data: number[], label: string }[] = [];
   chartOptions: ChartOptions = {
-    responsive: true, color: 'black', scales: {
+    responsive: true, maintainAspectRatio: false, color: 'black', scales: {
       x: {
         reverse: true,
         ticks: {

--- a/frontend/src/app/content/content.component.css
+++ b/frontend/src/app/content/content.component.css
@@ -12,17 +12,6 @@
   color: var(--main-color-dark);
 }
 
-#main-chart {
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-#main-chart img {
-  width: 80%;
-}
-
 #container_desktop {
   max-width: 1440px;
   margin-left: auto;
@@ -40,4 +29,10 @@
   flex-wrap: wrap;
   justify-content: center;
   gap: 60px
+}
+
+#main-chart {
+  height: calc(100vh - 194px);
+  justify-content: center;
+  align-items: center;
 }

--- a/frontend/src/app/content/content.component.css
+++ b/frontend/src/app/content/content.component.css
@@ -1,5 +1,6 @@
 #main-chart-title {
   text-align: center;
+  padding-bottom: 20px;
 }
 
 #main-chart-title span {
@@ -35,4 +36,6 @@
   height: calc(100vh - 194px);
   justify-content: center;
   align-items: center;
+  background-color: white;
+  border-radius:12px;
 }

--- a/frontend/src/app/content/content.component.html
+++ b/frontend/src/app/content/content.component.html
@@ -4,7 +4,7 @@
       <span>Wykres</span>
     </div>
     <div id="main-chart">
-      <img src="/assets/images/charts/placeholderChartIcon.png" alt="chartPlaceholder"/>
+      <app-chart></app-chart>
     </div>
   </div>
   <div id="container_desktop">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -54,7 +54,7 @@ body {
   }
 }
 
-@media (min-width: 768px) {
+@media (min-height: 650px) and (min-width: 768px) {
   /* Hide mobile */
   #container_mobile {
     display: none;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -33,6 +33,10 @@ body {
   max-width: calc(80vw);
 }
 
+.modal-content {
+  height: calc(80vh);
+  display: block;
+}
 
 /* breakpoints */
 @media (min-width: 0) {


### PR DESCRIPTION
Dodałem pusty chart na mobilke + mobilka na telefonach zostaje także po obróceniu ekranu, co pozwala na pokazanie wykresu w jakimś rozsądnym rozmiarze. 
Backend mi aktualnie nie działa, więc trzeba sprawdzić, czy w modalu i mobilce nic się nie psuje po załadowaniu danych i resizowaniu.